### PR TITLE
fix baudRate undefined if baud rate was never set

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@ Baud:
         try {
             // Prompt user to select any serial port.
             port = await navigator.serial.requestPort();
-            await port.open({ baudRate: localStorage.baud });
+            await port.open({ baudRate: localStorage.baud == undefined ? 9600 : localStorage.baud });
             listenToPort();
 
             textEncoder = new TextEncoderStream();


### PR DESCRIPTION
`localStorage.baud` is only set when changing the baud rate menu, so when that has never been done the page tried to connect with a baudRate undefined, despite showing the default value of 9600. Fixed by testing if `localStorage.baud` is undefined in `port.open`.